### PR TITLE
Add fix for supporting offline models

### DIFF
--- a/huggingface/cocolm/modeling_cocolm.py
+++ b/huggingface/cocolm/modeling_cocolm.py
@@ -159,7 +159,7 @@ class COCOLMPreTrainedModel(PreTrainedModel):
             del state_dict
         if pretrained_model_name_or_path in pretrained_model_archive_map:
             pretrained_model_name_or_path = pretrained_model_archive_map[pretrained_model_name_or_path]
-        else:
+        elif not os.path.isfile(pretrained_model_name_or_path):
             pretrained_model_name_or_path = 'microsoft/cocolm-large'  
         return super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
 


### PR DESCRIPTION
A small fix so offline local models can also be used as otherwise cocolm defaults to downloading from huggingface . This is useful for kaggle competitions as an example 